### PR TITLE
[breaking] Don't connect on initialisation by default, closes #63

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -5,6 +5,7 @@
 ---
 
  - [miniplug(opts)](#mp-constructor)
+ - [mp.connect({ email, password })](#mp-connect)
  - [mp.use(plugin)](#mp-use)
  - [mp.join(room)](#mp-join)
  - [mp.room()](#mp-room)
@@ -237,23 +238,52 @@ the plug.dj API.
 <a id="mp-constructor"></a>
 ## mp = miniplug(opts={})
 
-Create a miniplug instance. Available options:
+Create a miniplug instance.
 
- - `opts.guest` - If true, will log in as a guest user. Defaults to false.
- - `opts.email` and `opts.password` - Login credentials. Only email/password
-   login is supported at the moment.
+ - `opts.host` - The plug.dj host to use, defaults to `https://plug.dj/`.
+   This can be changed for mocking or to run on a plug.dj subdomain like `stg.`.
+
+Note that a miniplug instance is not very useful until you open a
+[connection](#mp-connect) to plug.dj.
 
 ```js
 const miniplug = require('miniplug')
 
-const mp = miniplug({ guest: true })
+const mp = miniplug()
+```
+
+<a id="mp-connect"></a>
+## mp.connect(opts): Promise&lt;this>
+
+Connect to plug.dj. Available options:
+
+ - `opts.guest` - If true, will log in as a guest user. Defaults to false.
+ - `opts.email` and `opts.password` - Login credentials. Only email/password
+   login is supported and support for Facebook login is not currently planned.
+
+```js
+const mp = miniplug()
+mp.connect({ guest: true }).then(() => {
+  // ready
+})
 ```
 
 ```js
-const mp = miniplug({
+const mp = miniplug()
+mp.connect({
   email: 'example@test.com',
   password: 'hunter2'
+}).then(() => {
+  // ready
 })
+```
+
+This method returns `this` so you can use async/await syntax to do:
+
+```js
+async function main () {
+  const mp = await miniplug().connect({ /* ... */ })
+}
 ```
 
 <a id="mp-use"></a>

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,7 @@ export default miniplug
 
 const debug = createDebug('miniplug:miniplug')
 const defaultOptions = {
-  host: 'https://plug.dj',
-  connect: true
+  host: 'https://plug.dj'
 }
 
 function miniplug (opts = {}) {
@@ -122,8 +121,6 @@ function miniplug (opts = {}) {
     // REST: News APIs
     getNews: partial(mp.get, 'news')
   })
-
-  if (opts.connect) mp.connect(opts)
 
   return mp
 }

--- a/src/plugins/connect.js
+++ b/src/plugins/connect.js
@@ -62,7 +62,9 @@ export default function connectPlugin (options = {}) {
       mp.ws = ws
       mp.connected = connected
 
-      return connected
+      // Return `mp` so you can do
+      // mp = await miniplug().connect()
+      return connected.then(() => mp)
     }
 
     mp.connect = connect

--- a/test/mocks/mp.js
+++ b/test/mocks/mp.js
@@ -28,9 +28,7 @@ const socket = require('proxyquire')('plug-socket', {
 })
 
 module.exports = () => {
-  const mp = miniplug({
-    connect: false
-  })
+  const mp = miniplug()
 
   mp.ws = socket()
 


### PR DESCRIPTION
Removes the implicit connect() call, because it was difficult to get the
Error from it if it went wrong. Users must now instead call
`mp.connect()` manually, and they can attach `.catch()` listeners
there.